### PR TITLE
fix: handle goavro native conversions

### DIFF
--- a/encoding/protoavro/marshal_test.go
+++ b/encoding/protoavro/marshal_test.go
@@ -3,14 +3,21 @@ package protoavro_test
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/einride/protobuf-avro-go/encoding/protoavro"
+	examplev1 "github.com/einride/protobuf-avro-go/internal/examples/proto/gen/einride/avro/example/v1"
 	"google.golang.org/genproto/googleapis/example/library/v1"
+	"google.golang.org/genproto/googleapis/type/date"
+	"google.golang.org/genproto/googleapis/type/timeofday"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gotest.tools/v3/assert"
 )
 
-func Test_Marshaler(t *testing.T) {
+func Test_MarshalUnmarshal(t *testing.T) {
 	msgs := []*library.Book{
 		{
 			Name:   "shelves/1/books/1",
@@ -44,4 +51,63 @@ func Test_Marshaler(t *testing.T) {
 	}
 
 	assert.DeepEqual(t, msgs, got, protocmp.Transform())
+}
+
+func Test_MarshalSymmetric(t *testing.T) {
+	// when `goavro` decodes a file, it will not read back exactly what was
+	// written. For example timestamps are returned as `time.Time`. These
+	// tests assert that those conversions are handled properly.
+	for _, tt := range []struct {
+		name string
+		msg  proto.Message
+	}{
+		{
+			name: "examplev1.ExampleTimestamp",
+			msg: &examplev1.ExampleTimestamp{
+				Timestamp: timestamppb.New(time.Now().Truncate(time.Microsecond)), // nano second precision not expressible in avro
+			},
+		},
+		{
+			name: "examplev1.ExampleDate",
+			msg: &examplev1.ExampleDate{
+				Date: &date.Date{Year: 2021, Month: 1, Day: 1},
+			},
+		},
+		{
+			name: "examplev1.ExampleDuration",
+			msg: &examplev1.ExampleDuration{
+				Duration: durationpb.New(time.Hour),
+			},
+		},
+		{
+			name: "examplev1.TimeOfDay",
+			msg: &examplev1.ExampleTimeOfDay{
+				TimeOfDay: &timeofday.TimeOfDay{Hours: 20},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+
+			// marshal messages
+			marshaller, err := protoavro.NewMarshaler(tt.msg.ProtoReflect().Descriptor(), &b)
+			assert.NilError(t, err)
+			assert.NilError(t, marshaller.Append(tt.msg))
+
+			// unmarshal messages
+			unmarshaler, err := protoavro.NewUnmarshaler(&b)
+			assert.NilError(t, err)
+			got := make([]proto.Message, 0, 2)
+			for unmarshaler.Scan() {
+				msg := proto.Clone(tt.msg)
+				proto.Reset(msg)
+
+				assert.NilError(t, unmarshaler.Read(msg))
+				got = append(got, msg)
+			}
+			assert.Equal(t, len(got), 1)
+			assert.DeepEqual(t, tt.msg, got[0], protocmp.Transform())
+		})
+	}
 }


### PR DESCRIPTION
When `goavro` decodes a file, it will not read back exactly what was
written. For example timestamps are returned as `time.Time`.
