### PR TITLE
feat: make all fields in records nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,24 @@ Avro schema inference for arbitrary protobuf messages.
 
 ```go
 func ExampleInferSchema() {
-    msg := &library.Book{}
-    schema, err := protoavro.InferSchema(msg.ProtoReflect().Descriptor())
-    if err != nil {
-        panic(err)
-    }
-    expected := avro.Nullable(avro.Record{
-        Type:      avro.RecordType,
-        Name:      "Book",
-        Namespace: "google.example.library.v1",
-        Fields: []avro.Field{
-            {Name: "name", Type: avro.String()},
-            {Name: "author", Type: avro.String()},
-            {Name: "title", Type: avro.String()},
-            {Name: "read", Type: avro.Boolean()},
-        },
-    })
-    fmt.Println(cmp.Equal(expected, schema))
+	msg := &library.Book{}
+	schema, err := protoavro.InferSchema(msg.ProtoReflect().Descriptor())
+	if err != nil {
+		panic(err)
+	}
+	expected := avro.Nullable(avro.Record{
+		Type:      avro.RecordType,
+		Name:      "Book",
+		Namespace: "google.example.library.v1",
+		Fields: []avro.Field{
+			{Name: "name", Type: avro.Nullable(avro.String())},
+			{Name: "author", Type: avro.Nullable(avro.String())},
+			{Name: "title", Type: avro.Nullable(avro.String())},
+			{Name: "read", Type: avro.Nullable(avro.Boolean())},
+		},
+	})
+	fmt.Println(cmp.Equal(expected, schema))
+	// Output: true
 }
 ```
 
@@ -99,7 +100,7 @@ func ExampleUnmarshaler() {
 
 ### Mapping
 
-**Messages** are mapped as nullable records in Avro. Fields will have the same casing as in the protobuf descriptor.
+**Messages** are mapped as nullable records in Avro. All fields will be nullable. Fields will have the same casing as in the protobuf descriptor.
 
 **One of**s are mapped to nullable fields in Avro, where at most one field will be set at a time.
 

--- a/encoding/protoavro/encode.go
+++ b/encoding/protoavro/encode.go
@@ -69,7 +69,7 @@ func fieldJSON(field protoreflect.FieldDescriptor, value protoreflect.Value) (in
 			}
 			list = append(list, fieldValue)
 		}
-		return list, nil
+		return unionValue("array", list), nil
 	}
 	if field.IsMap() {
 		return encodeMap(field, value.Map())
@@ -82,31 +82,34 @@ func fieldKindJSON(field protoreflect.FieldDescriptor, value protoreflect.Value)
 	case protoreflect.MessageKind, protoreflect.GroupKind:
 		return messageJSON(value.Message())
 	case protoreflect.EnumKind:
-		return string(field.Enum().Values().Get(int(value.Enum())).Name()), nil
+		return unionValue(
+			string(field.Enum().FullName()),
+			string(field.Enum().Values().Get(int(value.Enum())).Name()),
+		), nil
 	case protoreflect.StringKind:
-		return value.String(), nil
+		return unionValue("string", value.String()), nil
 	case protoreflect.Int32Kind,
 		protoreflect.Fixed32Kind,
 		protoreflect.Sfixed32Kind,
 		protoreflect.Sint32Kind:
-		return int32(value.Int()), nil
+		return unionValue("int", int32(value.Int())), nil
 	case protoreflect.Uint32Kind:
-		return int32(value.Uint()), nil
+		return unionValue("int", int32(value.Uint())), nil
 	case protoreflect.Int64Kind,
 		protoreflect.Fixed64Kind,
 		protoreflect.Sfixed64Kind,
 		protoreflect.Sint64Kind:
-		return value.Int(), nil
+		return unionValue("long", value.Int()), nil
 	case protoreflect.Uint64Kind:
-		return int64(value.Uint()), nil
+		return unionValue("long", int64(value.Uint())), nil
 	case protoreflect.BoolKind:
-		return value.Bool(), nil
+		return unionValue("boolean", value.Bool()), nil
 	case protoreflect.BytesKind:
-		return value.Bytes(), nil
+		return unionValue("bytes", value.Bytes()), nil
 	case protoreflect.DoubleKind:
-		return value.Float(), nil
+		return unionValue("double", value.Float()), nil
 	case protoreflect.FloatKind:
-		return float32(value.Float()), nil
+		return unionValue("float", float32(value.Float())), nil
 	}
 	return value.Interface(), nil
 }

--- a/encoding/protoavro/encoding_test.go
+++ b/encoding/protoavro/encoding_test.go
@@ -38,10 +38,10 @@ func Test_JSON(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"google.example.library.v1.Book": map[string]interface{}{
-					"name":   "books/1",
-					"author": "J. K. Rowling",
-					"title":  "Harry Potter",
-					"read":   true,
+					"name":   map[string]interface{}{"string": "books/1"},
+					"author": map[string]interface{}{"string": "J. K. Rowling"},
+					"title":  map[string]interface{}{"string": "Harry Potter"},
+					"read":   map[string]interface{}{"boolean": true},
 				},
 			},
 		},
@@ -59,10 +59,10 @@ func Test_JSON(t *testing.T) {
 				"google.example.library.v1.UpdateBookRequest": map[string]interface{}{
 					"book": map[string]interface{}{
 						"google.example.library.v1.Book": map[string]interface{}{
-							"name":   "books/1",
-							"author": "J. K. Rowling",
-							"title":  "Harry Potter",
-							"read":   false,
+							"name":   map[string]interface{}{"string": "books/1"},
+							"author": map[string]interface{}{"string": "J. K. Rowling"},
+							"title":  map[string]interface{}{"string": "Harry Potter"},
+							"read":   map[string]interface{}{"boolean": false},
 						},
 					},
 					"update_mask": nil,
@@ -94,7 +94,7 @@ func Test_JSON(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"einride.avro.example.v1.ExampleBytes": map[string]interface{}{
-					"bytes": []byte{1, 2, 3},
+					"bytes": map[string]interface{}{"bytes": []byte{1, 2, 3}},
 				},
 			},
 		},
@@ -131,13 +131,13 @@ func Test_JSON(t *testing.T) {
 				"einride.avro.example.v1.ExampleDateTime": map[string]interface{}{
 					"date_time": map[string]interface{}{
 						"google.type.DateTime": map[string]interface{}{
-							"year":      int32(2021),
-							"month":     int32(6),
-							"day":       int32(27),
-							"hours":     int32(18),
-							"minutes":   int32(6),
-							"seconds":   int32(30),
-							"nanos":     int32(2),
+							"year":      map[string]interface{}{"int": int32(2021)},
+							"month":     map[string]interface{}{"int": int32(6)},
+							"day":       map[string]interface{}{"int": int32(27)},
+							"hours":     map[string]interface{}{"int": int32(18)},
+							"minutes":   map[string]interface{}{"int": int32(6)},
+							"seconds":   map[string]interface{}{"int": int32(30)},
+							"nanos":     map[string]interface{}{"int": int32(2)},
 							"time_zone": nil,
 							"utc_offset": map[string]interface{}{
 								"float": float64(3600),
@@ -167,7 +167,7 @@ func Test_JSON(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"einride.avro.example.v1.ExampleEnum": map[string]interface{}{
-					"enum_value": "ENUM_VALUE2",
+					"enum_value": map[string]interface{}{"einride.avro.example.v1.ExampleEnum.Enum": "ENUM_VALUE2"},
 				},
 			},
 		},
@@ -194,30 +194,60 @@ func Test_JSON(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"einride.avro.example.v1.ExampleList": map[string]interface{}{
-					"int64_list":  []interface{}{int64(1), int64(2), int64(3)},
-					"string_list": []interface{}{"1", "2", "3"},
-					"enum_list": []interface{}{
-						"ENUM_UNSPECIFIED",
-						"ENUM_VALUE1",
-						"ENUM_VALUE2",
-					},
-					"nested_list": []interface{}{
-						map[string]interface{}{
-							"einride.avro.example.v1.ExampleList.Nested": map[string]interface{}{
-								"string_list": []interface{}{"1", "2", "3"},
-							},
-						},
-						map[string]interface{}{
-							"einride.avro.example.v1.ExampleList.Nested": map[string]interface{}{
-								"string_list": []interface{}{"4", "5", "6"},
-							},
+					"int64_list": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{"long": int64(1)},
+							map[string]interface{}{"long": int64(2)},
+							map[string]interface{}{"long": int64(3)},
 						},
 					},
-					"float_value_list": []interface{}{
-						nil,
-						map[string]interface{}{"float": float32(1)},
-						map[string]interface{}{"float": float32(2)},
-						map[string]interface{}{"float": float32(3)},
+					"string_list": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{"string": "1"},
+							map[string]interface{}{"string": "2"},
+							map[string]interface{}{"string": "3"},
+						},
+					},
+					"enum_list": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{"einride.avro.example.v1.ExampleList.Enum": "ENUM_UNSPECIFIED"},
+							map[string]interface{}{"einride.avro.example.v1.ExampleList.Enum": "ENUM_VALUE1"},
+							map[string]interface{}{"einride.avro.example.v1.ExampleList.Enum": "ENUM_VALUE2"},
+						},
+					},
+					"nested_list": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"einride.avro.example.v1.ExampleList.Nested": map[string]interface{}{
+									"string_list": map[string]interface{}{
+										"array": []interface{}{
+											map[string]interface{}{"string": "1"},
+											map[string]interface{}{"string": "2"},
+											map[string]interface{}{"string": "3"},
+										},
+									},
+								},
+							},
+							map[string]interface{}{
+								"einride.avro.example.v1.ExampleList.Nested": map[string]interface{}{
+									"string_list": map[string]interface{}{
+										"array": []interface{}{
+											map[string]interface{}{"string": "4"},
+											map[string]interface{}{"string": "5"},
+											map[string]interface{}{"string": "6"},
+										},
+									},
+								},
+							},
+						},
+					},
+					"float_value_list": map[string]interface{}{
+						"array": []interface{}{
+							nil,
+							map[string]interface{}{"float": float32(1)},
+							map[string]interface{}{"float": float32(2)},
+							map[string]interface{}{"float": float32(3)},
+						},
 					},
 				},
 			},
@@ -270,110 +300,130 @@ func Test_JSON(t *testing.T) {
 			},
 			expected: map[string]interface{}{
 				"einride.avro.example.v1.ExampleMap": map[string]interface{}{
-					"string_to_string": []interface{}{
-						map[string]interface{}{
-							"key":   "1",
-							"value": "a",
-						},
-						map[string]interface{}{
-							"key":   "2",
-							"value": "b",
+					"string_to_string": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"string": "1"},
+								"value": map[string]interface{}{"string": "a"},
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"string": "2"},
+								"value": map[string]interface{}{"string": "b"},
+							},
 						},
 					},
-					"string_to_nested": []interface{}{
-						map[string]interface{}{
-							"key": "1",
-							"value": map[string]interface{}{
-								"einride.avro.example.v1.ExampleMap.Nested": map[string]interface{}{
-									"string_to_string": []interface{}{
-										map[string]interface{}{
-											"key":   "1",
-											"value": "a",
+					"string_to_nested": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key": map[string]interface{}{"string": "1"},
+								"value": map[string]interface{}{
+									"einride.avro.example.v1.ExampleMap.Nested": map[string]interface{}{
+										"string_to_string": map[string]interface{}{
+											"array": []interface{}{
+												map[string]interface{}{
+													"key":   map[string]interface{}{"string": "1"},
+													"value": map[string]interface{}{"string": "a"},
+												},
+												map[string]interface{}{
+													"key":   map[string]interface{}{"string": "2"},
+													"value": map[string]interface{}{"string": "b"},
+												},
+											},
 										},
-										map[string]interface{}{
-											"key":   "2",
-											"value": "b",
+									},
+								},
+							},
+							map[string]interface{}{
+								"key": map[string]interface{}{"string": "3"},
+								"value": map[string]interface{}{
+									"einride.avro.example.v1.ExampleMap.Nested": map[string]interface{}{
+										"string_to_string": map[string]interface{}{
+											"array": []interface{}{
+												map[string]interface{}{
+													"key":   map[string]interface{}{"string": "3"},
+													"value": map[string]interface{}{"string": "c"},
+												},
+												map[string]interface{}{
+													"key":   map[string]interface{}{"string": "4"},
+													"value": map[string]interface{}{"string": "d"},
+												},
+											},
 										},
 									},
 								},
 							},
 						},
-						map[string]interface{}{
-							"key": "3",
-							"value": map[string]interface{}{
-								"einride.avro.example.v1.ExampleMap.Nested": map[string]interface{}{
-									"string_to_string": []interface{}{
-										map[string]interface{}{
-											"key":   "3",
-											"value": "c",
-										},
-										map[string]interface{}{
-											"key":   "4",
-											"value": "d",
-										},
-									},
-								},
+					},
+					"string_to_enum": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"string": "0"},
+								"value": map[string]interface{}{"einride.avro.example.v1.ExampleMap.Enum": "ENUM_UNSPECIFIED"},
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"string": "1"},
+								"value": map[string]interface{}{"einride.avro.example.v1.ExampleMap.Enum": "ENUM_VALUE1"},
 							},
 						},
 					},
-					"string_to_enum": []interface{}{
-						map[string]interface{}{
-							"key":   "0",
-							"value": "ENUM_UNSPECIFIED",
-						},
-						map[string]interface{}{
-							"key":   "1",
-							"value": "ENUM_VALUE1",
-						},
-					},
-					"int32_to_string": []interface{}{
-						map[string]interface{}{
-							"key":   int32(1),
-							"value": "a",
-						},
-						map[string]interface{}{
-							"key":   int32(2),
-							"value": "b",
+					"int32_to_string": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"int": int32(1)},
+								"value": map[string]interface{}{"string": "a"},
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"int": int32(2)},
+								"value": map[string]interface{}{"string": "b"},
+							},
 						},
 					},
-					"int64_to_string": []interface{}{
-						map[string]interface{}{
-							"key":   int64(1),
-							"value": "a",
-						},
-						map[string]interface{}{
-							"key":   int64(2),
-							"value": "b",
-						},
-					},
-					"uint32_to_string": []interface{}{
-						map[string]interface{}{
-							"key":   int32(1),
-							"value": "a",
-						},
-						map[string]interface{}{
-							"key":   int32(2),
-							"value": "b",
+					"int64_to_string": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"long": int64(1)},
+								"value": map[string]interface{}{"string": "a"},
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"long": int64(2)},
+								"value": map[string]interface{}{"string": "b"},
+							},
 						},
 					},
-					"bool_to_string": []interface{}{
-						map[string]interface{}{
-							"key":   false,
-							"value": "b",
-						},
-						map[string]interface{}{
-							"key":   true,
-							"value": "a",
+					"uint32_to_string": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"int": int32(1)},
+								"value": map[string]interface{}{"string": "a"},
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"int": int32(2)},
+								"value": map[string]interface{}{"string": "b"},
+							},
 						},
 					},
-					"string_to_float_value": []interface{}{
-						map[string]interface{}{
-							"key":   "1",
-							"value": nil,
+					"bool_to_string": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"boolean": false},
+								"value": map[string]interface{}{"string": "b"},
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"boolean": true},
+								"value": map[string]interface{}{"string": "a"},
+							},
 						},
-						map[string]interface{}{
-							"key":   "2",
-							"value": map[string]interface{}{"float": float32(2)},
+					},
+					"string_to_float_value": map[string]interface{}{
+						"array": []interface{}{
+							map[string]interface{}{
+								"key":   map[string]interface{}{"string": "1"},
+								"value": nil,
+							},
+							map[string]interface{}{
+								"key":   map[string]interface{}{"string": "2"},
+								"value": map[string]interface{}{"float": float32(2)},
+							},
 						},
 					},
 				},

--- a/encoding/protoavro/map.go
+++ b/encoding/protoavro/map.go
@@ -13,10 +13,10 @@ func (s schemaInferrer) inferMapSchema(field protoreflect.FieldDescriptor) (avro
 	if err != nil {
 		return nil, err
 	}
-	return avro.Array{
+	return avro.Nullable(avro.Array{
 		Type:  avro.ArrayType,
 		Items: fieldKind,
-	}, nil
+	}), nil
 }
 
 func encodeMap(field protoreflect.FieldDescriptor, m protoreflect.Map) (interface{}, error) {
@@ -52,13 +52,13 @@ func encodeMap(field protoreflect.FieldDescriptor, m protoreflect.Map) (interfac
 			"value": valueValue,
 		})
 	}
-	return entries, nil
+	return unionValue("array", entries), nil
 }
 
 func decodeMap(data interface{}, f protoreflect.FieldDescriptor, mp protoreflect.Map) error {
-	list, ok := data.([]interface{})
-	if !ok {
-		return fmt.Errorf("expected list, got %T for '%s'", data, f.Name())
+	list, err := decodeListLike(data, "array")
+	if err != nil {
+		return err
 	}
 	return decodeMapEntries(list, f, mp)
 }

--- a/encoding/protoavro/map_test.go
+++ b/encoding/protoavro/map_test.go
@@ -22,31 +22,31 @@ func Test_MapSchema(t *testing.T) {
 			name:      "string to string",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "string_to_string",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "StringToStringEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.String()},
-						{Name: "value", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.String())},
+						{Name: "value", Type: avro.Nullable(avro.String())},
 					},
 				},
-			},
+			}),
 		},
 		{
 			name:      "nested map",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "string_to_nested",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "StringToNestedEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.String())},
 						{
 							Name: "value",
 							Type: avro.Nullable(avro.Record{
@@ -56,40 +56,40 @@ func Test_MapSchema(t *testing.T) {
 								Fields: []avro.Field{
 									{
 										Name: "string_to_string",
-										Type: avro.Array{
+										Type: avro.Nullable(avro.Array{
 											Type: avro.ArrayType,
 											Items: avro.Record{
 												Type:      avro.RecordType,
 												Name:      "StringToStringEntry",
 												Namespace: "einride.avro.example.v1.ExampleMap.Nested",
 												Fields: []avro.Field{
-													{Name: "key", Type: avro.String()},
-													{Name: "value", Type: avro.String()},
+													{Name: "key", Type: avro.Nullable(avro.String())},
+													{Name: "value", Type: avro.Nullable(avro.String())},
 												},
 											},
-										},
+										}),
 									},
 								},
 							}),
 						},
 					},
 				},
-			},
+			}),
 		},
 		{
 			name:      "enum value",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "string_to_enum",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "StringToEnumEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.String())},
 						{
-							Name: "value", Type: avro.Enum{
+							Name: "value", Type: avro.Nullable(avro.Enum{
 								Type:      avro.EnumType,
 								Name:      "Enum",
 								Namespace: "einride.avro.example.v1.ExampleMap",
@@ -98,79 +98,79 @@ func Test_MapSchema(t *testing.T) {
 									"ENUM_VALUE1",
 									"ENUM_VALUE2",
 								},
-							},
+							}),
 						},
 					},
 				},
-			},
+			}),
 		},
 		{
 			name:      "int32 key",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "int32_to_string",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "Int32ToStringEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.Integer()},
-						{Name: "value", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.Integer())},
+						{Name: "value", Type: avro.Nullable(avro.String())},
 					},
 				},
-			},
+			}),
 		},
 		{
 			name:      "int64 key",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "int64_to_string",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "Int64ToStringEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.Long()},
-						{Name: "value", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.Long())},
+						{Name: "value", Type: avro.Nullable(avro.String())},
 					},
 				},
-			},
+			}),
 		},
 		{
 			name:      "uint32 key",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "uint32_to_string",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "Uint32ToStringEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.Integer()},
-						{Name: "value", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.Integer())},
+						{Name: "value", Type: avro.Nullable(avro.String())},
 					},
 				},
-			},
+			}),
 		},
 		{
 			name:      "bool key",
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "bool_to_string",
-			expected: avro.Array{
+			expected: avro.Nullable(avro.Array{
 				Type: avro.ArrayType,
 				Items: avro.Record{
 					Type:      avro.RecordType,
 					Name:      "BoolToStringEntry",
 					Namespace: "einride.avro.example.v1.ExampleMap",
 					Fields: []avro.Field{
-						{Name: "key", Type: avro.Boolean()},
-						{Name: "value", Type: avro.String()},
+						{Name: "key", Type: avro.Nullable(avro.Boolean())},
+						{Name: "value", Type: avro.Nullable(avro.String())},
 					},
 				},
-			},
+			}),
 		},
 	} {
 		tt := tt
@@ -199,10 +199,21 @@ func Test_MapEncode(t *testing.T) {
 				},
 			},
 			fieldName: "string_to_string",
-			expected: []interface{}{
-				map[string]interface{}{"key": "1", "value": "a"},
-				map[string]interface{}{"key": "2", "value": "b"},
-				map[string]interface{}{"key": "3", "value": "c"},
+			expected: map[string]interface{}{
+				"array": []interface{}{
+					map[string]interface{}{
+						"key":   map[string]interface{}{"string": "1"},
+						"value": map[string]interface{}{"string": "a"},
+					},
+					map[string]interface{}{
+						"key":   map[string]interface{}{"string": "2"},
+						"value": map[string]interface{}{"string": "b"},
+					},
+					map[string]interface{}{
+						"key":   map[string]interface{}{"string": "3"},
+						"value": map[string]interface{}{"string": "c"},
+					},
+				},
 			},
 		},
 		{
@@ -215,10 +226,21 @@ func Test_MapEncode(t *testing.T) {
 				},
 			},
 			fieldName: "int32_to_string",
-			expected: []interface{}{
-				map[string]interface{}{"key": int32(1), "value": "a"},
-				map[string]interface{}{"key": int32(2), "value": "b"},
-				map[string]interface{}{"key": int32(3), "value": "c"},
+			expected: map[string]interface{}{
+				"array": []interface{}{
+					map[string]interface{}{
+						"key":   map[string]interface{}{"int": int32(1)},
+						"value": map[string]interface{}{"string": "a"},
+					},
+					map[string]interface{}{
+						"key":   map[string]interface{}{"int": int32(2)},
+						"value": map[string]interface{}{"string": "b"},
+					},
+					map[string]interface{}{
+						"key":   map[string]interface{}{"int": int32(3)},
+						"value": map[string]interface{}{"string": "c"},
+					},
+				},
 			},
 		},
 	} {
@@ -264,7 +286,7 @@ func Test_MapDecode(t *testing.T) {
 			msg:       &examplev1.ExampleMap{},
 			fieldName: "string_to_string",
 			data:      map[string]int32{},
-			expectErr: "expected list, got map[string]int32 for 'string_to_string'",
+			expectErr: "expected list-like, got map[]",
 		},
 		{
 			name:      "invalid element type",

--- a/encoding/protoavro/schema.go
+++ b/encoding/protoavro/schema.go
@@ -44,6 +44,8 @@ func (s schemaInferrer) inferMessageSchema(message protoreflect.MessageDescripto
 		if err != nil {
 			return nil, err
 		}
+
+		fieldSchema.Type = avro.Nullable(fieldSchema.Type)
 		record.Fields = append(
 			record.Fields,
 			fieldSchema,
@@ -82,7 +84,7 @@ func (s schemaInferrer) inferField(field protoreflect.FieldDescriptor) (avro.Fie
 			Doc:  doc,
 			Type: avro.Array{
 				Type:  avro.ArrayType,
-				Items: fieldKind,
+				Items: avro.Nullable(fieldKind),
 			},
 		}, nil
 	}

--- a/encoding/protoavro/schema_example_test.go
+++ b/encoding/protoavro/schema_example_test.go
@@ -20,10 +20,10 @@ func ExampleInferSchema() {
 		Name:      "Book",
 		Namespace: "google.example.library.v1",
 		Fields: []avro.Field{
-			{Name: "name", Type: avro.String()},
-			{Name: "author", Type: avro.String()},
-			{Name: "title", Type: avro.String()},
-			{Name: "read", Type: avro.Boolean()},
+			{Name: "name", Type: avro.Nullable(avro.String())},
+			{Name: "author", Type: avro.Nullable(avro.String())},
+			{Name: "title", Type: avro.Nullable(avro.String())},
+			{Name: "read", Type: avro.Nullable(avro.Boolean())},
 		},
 	})
 	fmt.Println(cmp.Equal(expected, schema))

--- a/encoding/protoavro/schema_test.go
+++ b/encoding/protoavro/schema_test.go
@@ -24,10 +24,10 @@ func TestInferSchema(t *testing.T) {
 				Name:      "Book",
 				Namespace: "google.example.library.v1",
 				Fields: []avro.Field{
-					{Name: "name", Type: avro.String()},
-					{Name: "author", Type: avro.String()},
-					{Name: "title", Type: avro.String()},
-					{Name: "read", Type: avro.Boolean()},
+					{Name: "name", Type: avro.Nullable(avro.String())},
+					{Name: "author", Type: avro.Nullable(avro.String())},
+					{Name: "title", Type: avro.Nullable(avro.String())},
+					{Name: "read", Type: avro.Nullable(avro.Boolean())},
 				},
 			}),
 		},
@@ -46,10 +46,10 @@ func TestInferSchema(t *testing.T) {
 							Name:      "Book",
 							Namespace: "google.example.library.v1",
 							Fields: []avro.Field{
-								{Name: "name", Type: avro.String()},
-								{Name: "author", Type: avro.String()},
-								{Name: "title", Type: avro.String()},
-								{Name: "read", Type: avro.Boolean()},
+								{Name: "name", Type: avro.Nullable(avro.String())},
+								{Name: "author", Type: avro.Nullable(avro.String())},
+								{Name: "title", Type: avro.Nullable(avro.String())},
+								{Name: "read", Type: avro.Nullable(avro.Boolean())},
 							},
 						}),
 					},
@@ -62,10 +62,10 @@ func TestInferSchema(t *testing.T) {
 							Fields: []avro.Field{
 								{
 									Name: "paths",
-									Type: avro.Array{
+									Type: avro.Nullable(avro.Array{
 										Type:  avro.ArrayType,
-										Items: avro.String(),
-									},
+										Items: avro.Nullable(avro.String()),
+									}),
 								},
 							},
 						}),
@@ -100,7 +100,7 @@ func TestInferSchema(t *testing.T) {
 				Fields: []avro.Field{
 					{
 						Name: "bytes",
-						Type: avro.Bytes(),
+						Type: avro.Nullable(avro.Bytes()),
 					},
 				},
 			}),
@@ -132,13 +132,13 @@ func TestInferSchema(t *testing.T) {
 							Name:      "DateTime",
 							Namespace: "google.type",
 							Fields: []avro.Field{
-								{Name: "year", Type: avro.Integer()},
-								{Name: "month", Type: avro.Integer()},
-								{Name: "day", Type: avro.Integer()},
-								{Name: "hours", Type: avro.Integer()},
-								{Name: "minutes", Type: avro.Integer()},
-								{Name: "seconds", Type: avro.Integer()},
-								{Name: "nanos", Type: avro.Integer()},
+								{Name: "year", Type: avro.Nullable(avro.Integer())},
+								{Name: "month", Type: avro.Nullable(avro.Integer())},
+								{Name: "day", Type: avro.Nullable(avro.Integer())},
+								{Name: "hours", Type: avro.Nullable(avro.Integer())},
+								{Name: "minutes", Type: avro.Nullable(avro.Integer())},
+								{Name: "seconds", Type: avro.Nullable(avro.Integer())},
+								{Name: "nanos", Type: avro.Nullable(avro.Integer())},
 								{
 									Name: "utc_offset",
 									Doc:  "At most one will be set:\n* utc_offset\n* time_zone",
@@ -152,8 +152,8 @@ func TestInferSchema(t *testing.T) {
 										Name:      "TimeZone",
 										Namespace: "google.type",
 										Fields: []avro.Field{
-											{Name: "id", Type: avro.String()},
-											{Name: "version", Type: avro.String()},
+											{Name: "id", Type: avro.Nullable(avro.String())},
+											{Name: "version", Type: avro.Nullable(avro.String())},
 										},
 									}),
 								},
@@ -185,7 +185,7 @@ func TestInferSchema(t *testing.T) {
 				Fields: []avro.Field{
 					{
 						Name: "enum_value",
-						Type: avro.Enum{
+						Type: avro.Nullable(avro.Enum{
 							Type:      avro.EnumType,
 							Name:      "Enum",
 							Namespace: "einride.avro.example.v1.ExampleEnum",
@@ -194,7 +194,7 @@ func TestInferSchema(t *testing.T) {
 								"ENUM_VALUE1",
 								"ENUM_VALUE2",
 							},
-						},
+						}),
 					},
 				},
 			}),
@@ -209,23 +209,23 @@ func TestInferSchema(t *testing.T) {
 				Fields: []avro.Field{
 					{
 						Name: "int64_list",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type:  avro.ArrayType,
-							Items: avro.Long(),
-						},
+							Items: avro.Nullable(avro.Long()),
+						}),
 					},
 					{
 						Name: "string_list",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type:  avro.ArrayType,
-							Items: avro.String(),
-						},
+							Items: avro.Nullable(avro.String()),
+						}),
 					},
 					{
 						Name: "enum_list",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
-							Items: avro.Enum{
+							Items: avro.Nullable(avro.Enum{
 								Type:      avro.EnumType,
 								Name:      "Enum",
 								Namespace: "einride.avro.example.v1.ExampleList",
@@ -234,12 +234,12 @@ func TestInferSchema(t *testing.T) {
 									"ENUM_VALUE1",
 									"ENUM_VALUE2",
 								},
-							},
-						},
+							}),
+						}),
 					},
 					{
 						Name: "nested_list",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Nullable(avro.Record{
 								Type:      avro.RecordType,
@@ -248,21 +248,21 @@ func TestInferSchema(t *testing.T) {
 								Fields: []avro.Field{
 									{
 										Name: "string_list",
-										Type: avro.Array{
+										Type: avro.Nullable(avro.Array{
 											Type:  avro.ArrayType,
-											Items: avro.String(),
-										},
+											Items: avro.Nullable(avro.String()),
+										}),
 									},
 								},
 							}),
-						},
+						}),
 					},
 					{
 						Name: "float_value_list",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type:  avro.ArrayType,
 							Items: avro.Nullable(avro.Float()),
-						},
+						}),
 					},
 				},
 			}),
@@ -277,29 +277,29 @@ func TestInferSchema(t *testing.T) {
 				Fields: []avro.Field{
 					{
 						Name: "string_to_string",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "StringToStringEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.String()},
-									{Name: "value", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.String())},
+									{Name: "value", Type: avro.Nullable(avro.String())},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "string_to_nested",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "StringToNestedEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.String())},
 									{
 										Name: "value",
 										Type: avro.Nullable(avro.Record{
@@ -309,39 +309,39 @@ func TestInferSchema(t *testing.T) {
 											Fields: []avro.Field{
 												{
 													Name: "string_to_string",
-													Type: avro.Array{
+													Type: avro.Nullable(avro.Array{
 														Type: avro.ArrayType,
 														Items: avro.Record{
 															Type:      avro.RecordType,
 															Name:      "StringToStringEntry",
 															Namespace: "einride.avro.example.v1.ExampleMap.Nested",
 															Fields: []avro.Field{
-																{Name: "key", Type: avro.String()},
-																{Name: "value", Type: avro.String()},
+																{Name: "key", Type: avro.Nullable(avro.String())},
+																{Name: "value", Type: avro.Nullable(avro.String())},
 															},
 														},
-													},
+													}),
 												},
 											},
 										}),
 									},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "string_to_enum",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "StringToEnumEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.String())},
 									{
 										Name: "value",
-										Type: avro.Enum{
+										Type: avro.Nullable(avro.Enum{
 											Type:      avro.EnumType,
 											Name:      "Enum",
 											Namespace: "einride.avro.example.v1.ExampleMap",
@@ -350,86 +350,86 @@ func TestInferSchema(t *testing.T) {
 												"ENUM_VALUE1",
 												"ENUM_VALUE2",
 											},
-										},
+										}),
 									},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "int32_to_string",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "Int32ToStringEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.Integer()},
-									{Name: "value", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.Integer())},
+									{Name: "value", Type: avro.Nullable(avro.String())},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "int64_to_string",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "Int64ToStringEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.Long()},
-									{Name: "value", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.Long())},
+									{Name: "value", Type: avro.Nullable(avro.String())},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "uint32_to_string",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "Uint32ToStringEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.Integer()},
-									{Name: "value", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.Integer())},
+									{Name: "value", Type: avro.Nullable(avro.String())},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "bool_to_string",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "BoolToStringEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.Boolean()},
-									{Name: "value", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.Boolean())},
+									{Name: "value", Type: avro.Nullable(avro.String())},
 								},
 							},
-						},
+						}),
 					},
 					{
 						Name: "string_to_float_value",
-						Type: avro.Array{
+						Type: avro.Nullable(avro.Array{
 							Type: avro.ArrayType,
 							Items: avro.Record{
 								Type:      avro.RecordType,
 								Name:      "StringToFloatValueEntry",
 								Namespace: "einride.avro.example.v1.ExampleMap",
 								Fields: []avro.Field{
-									{Name: "key", Type: avro.String()},
+									{Name: "key", Type: avro.Nullable(avro.String())},
 									{Name: "value", Type: avro.Nullable(avro.Float())},
 								},
 							},
-						},
+						}),
 					},
 				},
 			}),
@@ -470,7 +470,7 @@ func TestInferSchema(t *testing.T) {
 							Name:      "Message",
 							Namespace: "einride.avro.example.v1.ExampleOneof",
 							Fields: []avro.Field{
-								{Name: "string_value", Type: avro.String()},
+								{Name: "string_value", Type: avro.Nullable(avro.String())},
 							},
 						}),
 					},


### PR DESCRIPTION
Avro handles schema evolution slightly different than protobuf. By
default fields are REQUIRED in Avro unless specifically made NULLABLE.

This commit changes all fields in protobuf messages to be NULLABLE in
their mapped Avro record.
