### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func ExampleInferSchema() {
 
 ### `protoavro.Marshaler`
 
-Writes protobuf messages to an [Object Container File](https://avro.apache.org/docs/current/spec.html#Object+Container+Files).
+Writes protobuf messages to an [Object Container File](https://avro.apache.org/docs/current/specification/#object-container-files).
 
 ```go
 func ExampleMarshaler() {
@@ -75,7 +75,7 @@ func ExampleMarshaler() {
 
 ### `protoavro.Unmarshaler`
 
-Reads protobuf messages from a [Object Container File](https://avro.apache.org/docs/current/spec.html#Object+Container+Files).
+Reads protobuf messages from a [Object Container File](https://avro.apache.org/docs/current/specification/#object-container-files).
 
 ```go
 func ExampleUnmarshaler() {


### PR DESCRIPTION
### What
The link to Avro Object Container Files did not point to the Object Container Files section in the docs.

### Solution
Updated the link