### PR TITLE
Fix: return value 0 if ByNumber returns nil

### DIFF
--- a/encoding/protoavro/encode.go
+++ b/encoding/protoavro/encode.go
@@ -93,6 +93,12 @@ func (o SchemaOptions) fieldKindJSON(
 	case protoreflect.MessageKind, protoreflect.GroupKind:
 		return o.messageJSON(value.Message(), recursiveIndex)
 	case protoreflect.EnumKind:
+		if field.Enum().Values().ByNumber(value.Enum()) == nil {
+			return o.unionValue(
+				string(field.Enum().FullName()),
+				string(field.Enum().Values().ByNumber(protoreflect.EnumNumber(0)).Name()),
+			), nil
+		}
 		return o.unionValue(
 			string(field.Enum().FullName()),
 			string(field.Enum().Values().ByNumber(value.Enum()).Name()),

--- a/encoding/protoavro/encoding_test.go
+++ b/encoding/protoavro/encoding_test.go
@@ -728,6 +728,15 @@ func Test_OmitRoot_JSON(t *testing.T) {
 			},
 		},
 		{
+			name: "examplev1.ExampleEnumUnspecifiedNumber",
+			msg: &examplev1.ExampleEnum{
+				EnumValue: 1337,
+			},
+			expected: map[string]interface{}{
+				"enum_value": map[string]interface{}{"einride.avro.example.v1.ExampleEnum.Enum": "ENUM_UNSPECIFIED"},
+			},
+		},
+		{
 			name: "examplev1.ExampleList",
 			msg: &examplev1.ExampleList{
 				Int64List:  []int64{1, 2, 3},
@@ -1126,7 +1135,9 @@ func Test_OmitRoot_JSON(t *testing.T) {
 			next := proto.Clone(tt.msg)
 			proto.Reset(next)
 			assert.NilError(t, tt.opts.decodeJSON(got, next))
-			assert.DeepEqual(t, tt.msg, next, protocmp.Transform())
+			if tt.name != "examplev1.ExampleEnumUnspecifiedNumber" {
+				assert.DeepEqual(t, tt.msg, next, protocmp.Transform())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Alright, in #123  i said i couldn't think of a case where ByNumber would return nil with the way it was done in this code path. 

Turns out i didn't fully understand enums. 

enums in golang and various other languages treat enums as open https://protobuf.dev/programming-guides/enum/#definitions

Meaning that if you pass a value e.g. 1337, golang will report the field being set and instead of a nice enum value just represent it as 1337, then when using BynNmber i get nil and .Name() fails due to nil pointer. 

This fixes that to set unknown values to value 0. 

Sorry about that.

